### PR TITLE
Allow importing of factori definitions

### DIFF
--- a/factori-impl/src/define.rs
+++ b/factori-impl/src/define.rs
@@ -107,7 +107,7 @@ impl Definition {
             None => {
                 quote! {
                     #[allow(non_camel_case_types)]
-                    type #ident_builder = #ty;
+                    pub type #ident_builder = #ty;
 
                     impl factori::Default for #ident_builder {
                         fn default() -> Self {

--- a/tests/import.rs
+++ b/tests/import.rs
@@ -1,0 +1,62 @@
+#[macro_use]
+extern crate factori;
+
+pub struct Vehicle {
+    number_wheels: u8,
+    electric: bool,
+}
+
+pub mod vehicle_factory {
+    use super::Vehicle;
+
+    factori!(Vehicle, {
+        default {
+            number_wheels = 4,
+            electric = false,
+        }
+
+        feature bike {
+            number_wheels = 2,
+        }
+
+        feature electric {
+            electric = true,
+        }
+    });
+}
+
+use vehicle_factory::*;
+
+#[test]
+fn simple_struct() {
+    let default = create!(Vehicle);
+    assert_eq!(default.number_wheels, 4);
+    assert_eq!(default.electric, false);
+}
+
+#[test]
+fn override_field() {
+    let three_wheels = create!(Vehicle, number_wheels: 3);
+    assert_eq!(three_wheels.number_wheels, 3);
+}
+
+#[test]
+fn one_feature() {
+    let bike = create!(Vehicle, :bike);
+    assert_eq!(bike.number_wheels, 2);
+    assert_eq!(bike.electric, false);
+}
+
+#[test]
+fn feature_and_override() {
+    let electric_bike = create!(Vehicle, :bike, electric: true);
+    assert_eq!(electric_bike.number_wheels, 2);
+    assert_eq!(electric_bike.electric, true);
+}
+
+#[test]
+fn two_features() {
+    let electric_bike = create!(Vehicle, :bike, :electric);
+    assert_eq!(electric_bike.number_wheels, 2);
+    assert_eq!(electric_bike.electric, true);
+}


### PR DESCRIPTION
This PR would allow defining factories in a module that can be imported and used in other modules. Currently (unless I'm missing something), the `factori!` definition needs to be repeated wherever it is used.

