### PR TITLE
Allow clippy::needless_update in Builder::build

### DIFF
--- a/factori-impl/src/create.rs
+++ b/factori-impl/src/create.rs
@@ -91,12 +91,15 @@ pub fn create_macro(input: TokenStream) -> TokenStream {
     };
 
     let quoted = quote! {
-        factori::Builder::build(#ident_builder {
-            #(
-                #fields: #values,
-            )*
-            .. #value
-        })
+        factori::Builder::build(
+            #[allow(clippy::needless_update)]
+            #ident_builder {
+                #(
+                    #fields: #values,
+                )*
+                .. #value
+            }
+        )
     };
 
     quoted.into()


### PR DESCRIPTION
This removes a lot of clippy warnings for factori usages that have defaults for all fields of a struct which makes the `..factori::Default::default()` a needless update. This is ignores the warnings for this from clippy.